### PR TITLE
WIP: Test DHT with large number of nodes

### DIFF
--- a/libp2pdht/private/eth/p2p/discoveryv5/chronosim.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/chronosim.nim
@@ -1,0 +1,94 @@
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ChronoSim: simulation/emulation wrapper around Chronos
+
+import
+  std/[tables, deques],
+  chronos,
+  chronicles
+
+when(true): #enable network emulator
+  type
+    DatagramCallback* = proc(transp: DatagramTransport,
+                            remote: TransportAddress): Future[void] {.
+                        gcsafe, raises: [Defect].}
+
+    DatagramTransport* = ref object
+      udata*: pointer                 # User-driven pointer
+      local: TransportAddress         # Local address
+      callback: DatagramCallback      # Receive data callback
+      ingress: Deque[seq[byte]]
+      egress: Deque[(TransportAddress, seq[byte])]  # simple FIFO for now
+
+  var network = initTable[Port, DatagramTransport]()
+
+  proc `$`*(transp: DatagramTransport): string =
+    $transp.local
+
+  proc recvFrom[T](transp: DatagramTransport, remote: TransportAddress,
+              msg: sink seq[T], msglen = -1) =
+    info "recv from ", remote
+    {.gcsafe.}:
+      transp.ingress.addLast(msg)
+      # call the callback on remote
+      asyncCheck transp.callback(transp, remote)
+
+  proc getLatency(src: TransportAddress, dst: TransportAddress) : Duration =
+    50.milliseconds
+
+  proc getLineTime(transp: DatagramTransport, msg: seq[byte]) : Duration =
+    # let bandwith = transp.bandwidth
+    let bandwidth = 100 # Bytes/ms = KB/sec
+    (msg.len div bandwidth).milliseconds
+
+  proc sendTo*[T](transp: DatagramTransport, remote: TransportAddress,
+              msg: sink seq[T], msglen = -1) {.async.} =
+
+    #transp.egress.addLast(remote, msg)
+    #await sleepAsync(getLineTime(transp, msg))
+
+    await sleepAsync(getLatency(transp.local, remote))
+    {.gcsafe.}:
+      network[remote.port].recvFrom(transp.local, msg)
+
+  proc getMessage*(t: DatagramTransport,): seq[byte] {.
+      raises: [Defect, CatchableError].} =
+    #echo "getMessage "
+    t.ingress.popFirst()
+
+  proc close*(transp: DatagramTransport) =
+    debug "close"
+
+  proc closed*(transp: DatagramTransport): bool {.inline.} =
+    result = false
+
+  proc closeWait*(transp: DatagramTransport) {.async.} =
+    debug "closeWait "
+
+  proc getUserData*[T](transp: DatagramTransport): T {.inline.} =
+    ## Obtain user data stored in ``transp`` object.
+    result = cast[T](transp.udata)
+
+  proc newDatagramTransport*[T](cbproc: DatagramCallback,
+                            udata: ref T,
+                            local: TransportAddress = AnyAddress,
+                            ): DatagramTransport {.
+      raises: [Defect, CatchableError].} =
+    debug "new"
+    result = DatagramTransport()
+    GC_ref(udata)
+    result.udata = cast[pointer](udata)
+    result.local = local
+    result.callback = cbproc
+    {.gcsafe.}:
+      network[local.port] = result
+
+export seconds, milliseconds
+export TransportAddress, initTAddress
+export async, sleepAsync, complete, await
+export Future, FutureBase, newFuture, futureContinue
+export TransportOsError

--- a/libp2pdht/private/eth/p2p/discoveryv5/chronosim.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/chronosim.nim
@@ -15,7 +15,15 @@ logScope:
   topics = "ChronoSim"
 
 const
+  timeWarp = 1
   emulateDatagram = true
+
+# chronos uses SomeIntegerI64. We shoudl be more specific here to override
+proc milliseconds*(v: int): Duration {.inline.} =
+  chronos.milliseconds(v * timeWarp)
+
+proc seconds*(v: int): Duration {.inline.} =
+  chronos.seconds(v * timeWarp)
 
 when(emulateDatagram): #enable network emulator
   type

--- a/libp2pdht/private/eth/p2p/discoveryv5/chronosim.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/chronosim.nim
@@ -14,7 +14,10 @@ import
 logScope:
   topics = "ChronoSim"
 
-when(true): #enable network emulator
+const
+  emulateDatagram = true
+
+when(emulateDatagram): #enable network emulator
   type
     DatagramCallback* = proc(transp: DatagramTransport,
                             remote: TransportAddress): Future[void] {.

--- a/libp2pdht/private/eth/p2p/discoveryv5/chronosim.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/chronosim.nim
@@ -11,6 +11,9 @@ import
   chronos,
   chronicles
 
+logScope:
+  topics = "ChronoSim"
+
 when(true): #enable network emulator
   type
     DatagramCallback* = proc(transp: DatagramTransport,

--- a/libp2pdht/private/eth/p2p/discoveryv5/chronosim.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/chronosim.nim
@@ -7,7 +7,7 @@
 # ChronoSim: simulation/emulation wrapper around Chronos
 
 import
-  std/[tables, deques],
+  std/[tables, deques, random],
   chronos,
   chronicles
 
@@ -54,6 +54,8 @@ when(emulateDatagram): #enable network emulator
   proc getLatency(src: TransportAddress, dst: TransportAddress) : Duration =
     50.milliseconds
 
+  proc getLoss(src: TransportAddress, dst: TransportAddress) : float =
+    0.0
   proc getLineTime(transp: DatagramTransport, msg: seq[byte]) : Duration =
     # let bandwith = transp.bandwidth
     let bandwidth = 100 # Bytes/ms = KB/sec
@@ -64,6 +66,9 @@ when(emulateDatagram): #enable network emulator
 
     #transp.egress.addLast(remote, msg)
     #await sleepAsync(getLineTime(transp, msg))
+
+    if rand(1.0) < getLoss(transp.local, remote):
+      return
 
     await sleepAsync(getLatency(transp.local, remote))
     {.gcsafe.}:

--- a/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -938,6 +938,7 @@ proc revalidateLoop(d: Protocol) {.async.} =
   try:
     while true:
       await sleepAsync(milliseconds(d.rng[].rand(RevalidateMax)))
+      echo d.localNode.address.get().port, ": ", d.nodesDiscovered()
       let n = d.routingTable.nodeToRevalidate()
       if not n.isNil:
         traceAsyncErrors d.revalidateNode(n)

--- a/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -450,6 +450,11 @@ proc replaceNode(d: Protocol, n: Node) =
     # peers in the routing table.
     debug "Message request to bootstrap node failed", src=d.localNode, dst=n
 
+proc waitResponse*[T: SomeMessage](d: Protocol, node: Node, msg: T):
+    Future[Option[Message]] =
+  let reqId = RequestId.init(d.rng[])
+  result = d.waitMessage(node, reqId)
+  sendRequest(d, node, msg, reqId)
 
 proc waitMessage(d: Protocol, fromNode: Node, reqId: RequestId):
     Future[Option[Message]] =
@@ -461,6 +466,12 @@ proc waitMessage(d: Protocol, fromNode: Node, reqId: RequestId):
     if not res.finished:
       res.complete(none(Message))
   d.awaitedMessages[key] = result
+
+proc waitNodeResponses*[T: SomeMessage](d: Protocol, node: Node, msg: T):
+    Future[DiscResult[seq[SignedPeerRecord]]] =
+  let reqId = RequestId.init(d.rng[])
+  result = d.waitNodes(node, reqId)
+  sendRequest(d, node, msg, reqId)
 
 proc waitNodes(d: Protocol, fromNode: Node, reqId: RequestId):
     Future[DiscResult[seq[SignedPeerRecord]]] {.async.} =
@@ -490,23 +501,20 @@ proc waitNodes(d: Protocol, fromNode: Node, reqId: RequestId):
     discovery_message_requests_outgoing.inc(labelValues = ["no_response"])
     return err("Nodes message not received in time")
 
-proc sendRequest*[T: SomeMessage](d: Protocol, toId: NodeId, toAddr: Address, m: T):
-    RequestId =
+proc sendRequest*[T: SomeMessage](d: Protocol, toId: NodeId, toAddr: Address, m: T,
+    reqId: RequestId) =
   let
-    reqId = RequestId.init(d.rng[])
     message = encodeMessage(m, reqId)
 
   trace "Send message packet", dstId = toId, toAddr, kind = messageKind(T)
   discovery_message_requests_outgoing.inc()
 
   d.transport.sendMessage(toId, toAddr, message)
-  return reqId
 
-proc sendRequest*[T: SomeMessage](d: Protocol, toNode: Node, m: T):
-    RequestId =
+proc sendRequest*[T: SomeMessage](d: Protocol, toNode: Node, m: T,
+    reqId: RequestId) =
   doAssert(toNode.address.isSome())
   let
-    reqId = RequestId.init(d.rng[])
     message = encodeMessage(m, reqId)
 
   trace "Send message packet", dstId = toNode.id,
@@ -514,16 +522,15 @@ proc sendRequest*[T: SomeMessage](d: Protocol, toNode: Node, m: T):
   discovery_message_requests_outgoing.inc()
 
   d.transport.sendMessage(toNode, message)
-  return reqId
 
 proc ping*(d: Protocol, toNode: Node):
     Future[DiscResult[PongMessage]] {.async.} =
   ## Send a discovery ping message.
   ##
   ## Returns the received pong message or an error.
-  let reqId = d.sendRequest(toNode,
-    PingMessage(sprSeq: d.localNode.record.seqNum))
-  let resp = await d.waitMessage(toNode, reqId)
+  let
+    msg = PingMessage(sprSeq: d.localNode.record.seqNum)
+    resp = await d.waitResponse(toNode, msg)
 
   if resp.isSome():
     if resp.get().kind == pong:
@@ -544,8 +551,9 @@ proc findNode*(d: Protocol, toNode: Node, distances: seq[uint16]):
   ##
   ## Returns the received nodes or an error.
   ## Received SPRs are already validated and converted to `Node`.
-  let reqId = d.sendRequest(toNode, FindNodeMessage(distances: distances))
-  let nodes = await d.waitNodes(toNode, reqId)
+  let
+    msg = FindNodeMessage(distances: distances)
+    nodes = await d.waitNodeResponses(toNode, msg)
 
   if nodes.isOk:
     let res = verifyNodesRecords(nodes.get(), toNode, FindNodeResultLimit, distances)
@@ -561,8 +569,9 @@ proc findNodeFast*(d: Protocol, toNode: Node, target: NodeId):
   ##
   ## Returns the received nodes or an error.
   ## Received SPRs are already validated and converted to `Node`.
-  let reqId = d.sendRequest(toNode, FindNodeFastMessage(target: target))
-  let nodes = await d.waitNodes(toNode, reqId)
+  let
+    msg = FindNodeFastMessage(target: target)
+    nodes = await d.waitNodeResponses(toNode, msg)
 
   if nodes.isOk:
     let res = verifyNodesRecords(nodes.get(), toNode, FindNodeResultLimit)
@@ -578,9 +587,9 @@ proc talkReq*(d: Protocol, toNode: Node, protocol, request: seq[byte]):
   ## Send a discovery talkreq message.
   ##
   ## Returns the received talkresp message or an error.
-  let reqId = d.sendRequest(toNode,
-    TalkReqMessage(protocol: protocol, request: request))
-  let resp = await d.waitMessage(toNode, reqId)
+  let
+    msg = TalkReqMessage(protocol: protocol, request: request)
+    resp = await d.waitResponse(toNode, msg)
 
   if resp.isSome():
     if resp.get().kind == talkResp:
@@ -704,7 +713,8 @@ proc addProvider*(
       res.add(d.localNode)
   for toNode in res:
     if toNode != d.localNode:
-      discard d.sendRequest(toNode, AddProviderMessage(cId: cId, prov: pr))
+      let reqId = RequestId.init(d.rng[])
+      d.sendRequest(toNode, AddProviderMessage(cId: cId, prov: pr), reqId)
     else:
       asyncSpawn d.addProviderLocal(cId, pr)
 
@@ -717,8 +727,7 @@ proc sendGetProviders(d: Protocol, toNode: Node,
   trace "sendGetProviders", toNode, msg
 
   let
-    reqId = d.sendRequest(toNode, msg)
-    resp = await d.waitMessage(toNode, reqId)
+    resp = await d.waitResponse(toNode, msg)
 
   if resp.isSome():
     if resp.get().kind == MessageKind.providers:

--- a/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -947,7 +947,7 @@ proc revalidateLoop(d: Protocol) {.async.} =
   try:
     while true:
       await sleepAsync(milliseconds(RevalidateMax div 2 + d.rng[].rand(RevalidateMax div 2)))
-      echo d.localNode.address.get().port, ": ", d.nodesDiscovered()
+      #echo d.localNode.address.get().port, ": ", d.nodesDiscovered()
       let n = d.routingTable.nodeToRevalidate()
       if not n.isNil:
         traceAsyncErrors d.revalidateNode(n)

--- a/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -1032,7 +1032,7 @@ proc newProtocol*(
     bootstrapRecords: openArray[SignedPeerRecord] = [],
     previousRecord = none[SignedPeerRecord](),
     bindPort: Port,
-    bindIp = IPv4_any(),
+    bindIp = IPv4_loopback(),
     enrAutoUpdate = false,
     config = defaultDiscoveryConfig,
     rng = newRng(),
@@ -1099,7 +1099,7 @@ proc newProtocol*(
     bindPort: Port,
     record: SignedPeerRecord,
     bootstrapRecords: openArray[SignedPeerRecord] = [],
-    bindIp = IPv4_any(),
+    bindIp = IPv4_loopback(),
     config = defaultDiscoveryConfig,
     rng = newRng(),
     providers = ProvidersManager.new(SQLiteDatastore.new(Memory)

--- a/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -937,7 +937,7 @@ proc revalidateLoop(d: Protocol) {.async.} =
   ## message.
   try:
     while true:
-      await sleepAsync(milliseconds(d.rng[].rand(RevalidateMax)))
+      await sleepAsync(milliseconds(RevalidateMax div 2 + d.rng[].rand(RevalidateMax div 2)))
       echo d.localNode.address.get().port, ": ", d.nodesDiscovered()
       let n = d.routingTable.nodeToRevalidate()
       if not n.isNil:

--- a/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -450,6 +450,28 @@ proc replaceNode(d: Protocol, n: Node) =
     # peers in the routing table.
     debug "Message request to bootstrap node failed", src=d.localNode, dst=n
 
+proc sendRequest*[T: SomeMessage](d: Protocol, toId: NodeId, toAddr: Address, m: T,
+    reqId: RequestId) =
+  let
+    message = encodeMessage(m, reqId)
+
+  trace "Send message packet", dstId = toId, toAddr, kind = messageKind(T)
+  discovery_message_requests_outgoing.inc()
+
+  d.transport.sendMessage(toId, toAddr, message)
+
+proc sendRequest*[T: SomeMessage](d: Protocol, toNode: Node, m: T,
+    reqId: RequestId) =
+  doAssert(toNode.address.isSome())
+  let
+    message = encodeMessage(m, reqId)
+
+  trace "Send message packet", dstId = toNode.id,
+    address = toNode.address, kind = messageKind(T)
+  discovery_message_requests_outgoing.inc()
+
+  d.transport.sendMessage(toNode, message)
+
 proc waitResponse*[T: SomeMessage](d: Protocol, node: Node, msg: T):
     Future[Option[Message]] =
   let reqId = RequestId.init(d.rng[])
@@ -500,28 +522,6 @@ proc waitNodes(d: Protocol, fromNode: Node, reqId: RequestId):
   else:
     discovery_message_requests_outgoing.inc(labelValues = ["no_response"])
     return err("Nodes message not received in time")
-
-proc sendRequest*[T: SomeMessage](d: Protocol, toId: NodeId, toAddr: Address, m: T,
-    reqId: RequestId) =
-  let
-    message = encodeMessage(m, reqId)
-
-  trace "Send message packet", dstId = toId, toAddr, kind = messageKind(T)
-  discovery_message_requests_outgoing.inc()
-
-  d.transport.sendMessage(toId, toAddr, message)
-
-proc sendRequest*[T: SomeMessage](d: Protocol, toNode: Node, m: T,
-    reqId: RequestId) =
-  doAssert(toNode.address.isSome())
-  let
-    message = encodeMessage(m, reqId)
-
-  trace "Send message packet", dstId = toNode.id,
-    address = toNode.address, kind = messageKind(T)
-  discovery_message_requests_outgoing.inc()
-
-  d.transport.sendMessage(toNode, message)
 
 proc ping*(d: Protocol, toNode: Node):
     Future[DiscResult[PongMessage]] {.async.} =

--- a/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
@@ -29,7 +29,7 @@ type
     udata*: pointer                 # User-driven pointer
     local: TransportAddress         # Local address
 
-var network = initTable[TransportAddress, DatagramTransport]()
+var network = initTable[Port, DatagramTransport]()
 
 proc sendTo*[T](transp: DatagramTransport, remote: TransportAddress,
              msg: sink seq[T], msglen = -1) {.async.} =
@@ -63,7 +63,7 @@ proc newDatagramTransport*[T](cbproc: DatagramCallback,
   result.udata = cast[pointer](udata)
   result.local = local
   {.gcsafe.}:
-    network[local] = result
+    network[local.port] = result
 
 
 type

--- a/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
@@ -29,6 +29,8 @@ type
     udata*: pointer                 # User-driven pointer
     local: TransportAddress         # Local address
 
+var network = initTable[TransportAddress, DatagramTransport]()
+
 proc sendTo*[T](transp: DatagramTransport, remote: TransportAddress,
              msg: sink seq[T], msglen = -1) {.async.} =
   echo "sending to ", remote
@@ -60,6 +62,7 @@ proc newFakeDatagramTransport*[T](cbproc: DatagramCallback,
   GC_ref(udata)
   result.udata = cast[pointer](udata)
   result.local = local
+  network[local] = result
 
 
 type

--- a/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
@@ -52,7 +52,7 @@ proc getUserData*[T](transp: DatagramTransport): T {.inline.} =
   ## Obtain user data stored in ``transp`` object.
   result = cast[T](transp.udata)
 
-proc newFakeDatagramTransport*[T](cbproc: DatagramCallback,
+proc newDatagramTransport*[T](cbproc: DatagramCallback,
                            udata: ref T,
                            local: TransportAddress = AnyAddress,
                            ): DatagramTransport {.
@@ -232,7 +232,7 @@ proc open*[T](t: Transport[T]) {.raises: [Defect, CatchableError].} =
 
   # TODO allow binding to specific IP / IPv6 / etc
   let ta = initTAddress(t.bindAddress.ip, t.bindAddress.port)
-  t.transp = newFakeDatagramTransport(processClient[T], udata = t, local = ta)
+  t.transp = newDatagramTransport(processClient[T], udata = t, local = ta)
 
 proc close*(t: Transport) =
   t.transp.close

--- a/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
@@ -52,13 +52,13 @@ when(true): #enable network emulator
     t.ingress.popFirst()
 
   proc close*(transp: DatagramTransport) =
-    echo "close"
+    debug "close"
 
   proc closed*(transp: DatagramTransport): bool {.inline.} =
     result = false
 
   proc closeWait*(transp: DatagramTransport) {.async.} =
-    echo "closeWait "
+    debug "closeWait "
 
   proc getUserData*[T](transp: DatagramTransport): T {.inline.} =
     ## Obtain user data stored in ``transp`` object.
@@ -69,7 +69,7 @@ when(true): #enable network emulator
                             local: TransportAddress = AnyAddress,
                             ): DatagramTransport {.
       raises: [Defect, CatchableError].} =
-    echo "new"
+    debug "new"
     result = DatagramTransport()
     GC_ref(udata)
     result.udata = cast[pointer](udata)

--- a/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
@@ -62,7 +62,8 @@ proc newFakeDatagramTransport*[T](cbproc: DatagramCallback,
   GC_ref(udata)
   result.udata = cast[pointer](udata)
   result.local = local
-  network[local] = result
+  {.gcsafe.}:
+    network[local] = result
 
 
 type

--- a/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
@@ -26,7 +26,8 @@ type
                       gcsafe, raises: [Defect].}
 
   DatagramTransport = ref object
-      udata*: pointer                 # User-driven pointer
+    udata*: pointer                 # User-driven pointer
+    local: TransportAddress         # Local address
 
 proc sendTo*[T](transp: DatagramTransport, remote: TransportAddress,
              msg: sink seq[T], msglen = -1) {.async.} =
@@ -58,6 +59,7 @@ proc newFakeDatagramTransport*[T](cbproc: DatagramCallback,
   result = DatagramTransport()
   GC_ref(udata)
   result.udata = cast[pointer](udata)
+  result.local = local
 
 
 type

--- a/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
@@ -260,7 +260,7 @@ proc newTransport*[T](
   privKey: PrivateKey,
   localNode: Node,
   bindPort: Port,
-  bindIp = IPv4_any(),
+  bindIp = IPv4_loopback(), ## we could use 127.0.0.1 here for local tests
   rng = newRng()): Transport[T]=
 
   # TODO Consider whether this should be a Defect

--- a/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
@@ -29,7 +29,7 @@ when(true): #enable network emulator
     DatagramTransport = ref object
       udata*: pointer                 # User-driven pointer
       local: TransportAddress         # Local address
-      function: DatagramCallback      # Receive data callback
+      callback: DatagramCallback      # Receive data callback
       ingress: Deque[seq[byte]]
 
   var network = initTable[Port, DatagramTransport]()
@@ -74,7 +74,7 @@ when(true): #enable network emulator
     GC_ref(udata)
     result.udata = cast[pointer](udata)
     result.local = local
-    result.function = cbproc
+    result.callback = cbproc
     {.gcsafe.}:
       network[local.port] = result
 

--- a/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
@@ -45,10 +45,13 @@ when(true): #enable network emulator
       # call the callback on remote
       asyncCheck transp.callback(transp, remote)
 
+  proc getLatency(src: TransportAddress, dst: TransportAddress) : Duration =
+    50.milliseconds
+
   proc sendTo*[T](transp: DatagramTransport, remote: TransportAddress,
               msg: sink seq[T], msglen = -1) {.async.} =
     #echo "sending to ", remote
-    await sleepAsync(50.milliseconds)
+    await sleepAsync(getLatency(transp.local, remote))
     {.gcsafe.}:
       network[remote.port].recvFrom(transp.local, msg)
 

--- a/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
@@ -48,6 +48,7 @@ when(true): #enable network emulator
   proc sendTo*[T](transp: DatagramTransport, remote: TransportAddress,
               msg: sink seq[T], msglen = -1) {.async.} =
     #echo "sending to ", remote
+    await sleepAsync(50.milliseconds)
     {.gcsafe.}:
       network[remote.port].recvFrom(transp.local, msg)
 

--- a/tests/dht/test_providers.nim
+++ b/tests/dht/test_providers.nim
@@ -198,7 +198,7 @@ suite "Providers Tests: many nodes":
     signedPeerRec0 = privKey0.toSignedPeerRecord
     peerRec0 = signedPeerRec0.data
 
-    await sleepAsync(chronos.seconds(15))
+    await sleepAsync(chronos.seconds(90))
 
   teardownAll:
     for (n, _) in nodes: # if last test is enabled, we need nodes[1..^1] here

--- a/tests/dht/test_providers.nim
+++ b/tests/dht/test_providers.nim
@@ -179,7 +179,7 @@ suite "Providers Tests: two nodes":
     debug "Providers:", providers
     check (providers.len == 1 and providers[0].data.peerId == peerRec0.peerId)
 
-suite "Providers Tests: 20 nodes":
+suite "Providers Tests: many nodes":
 
   var
     rng: ref HmacDrbgContext
@@ -192,7 +192,7 @@ suite "Providers Tests: 20 nodes":
 
   setupAll:
     rng = newRng()
-    nodes = await bootstrapNetwork(nodecount=20)
+    nodes = await bootstrapNetwork(nodecount=1000)
     targetId = NodeId.example(rng)
     (node0, privKey0) = nodes[0]
     signedPeerRec0 = privKey0.toSignedPeerRecord

--- a/tests/dht/test_providers.nim
+++ b/tests/dht/test_providers.nim
@@ -192,7 +192,7 @@ suite "Providers Tests: many nodes":
 
   setupAll:
     rng = newRng()
-    nodes = await bootstrapNetwork(nodecount=1000)
+    nodes = await bootstrapNetwork(nodecount=1000, delay=10)
     targetId = NodeId.example(rng)
     (node0, privKey0) = nodes[0]
     signedPeerRec0 = privKey0.toSignedPeerRecord

--- a/tests/dht/test_providers.nim
+++ b/tests/dht/test_providers.nim
@@ -33,12 +33,16 @@ proc bootstrapNodes(
 
   debug "---- STARTING BOOSTRAPS ---"
   for i in 0..<nodecount:
-    let privKey = PrivateKey.example(rng)
-    let node = initDiscoveryNode(rng, privKey, localAddress(20302 + i), bootnodes)
-    await node.start()
-    result.add((node, privKey))
-    if delay > 0:
-      await sleepAsync(chronos.milliseconds(delay))
+    try:
+      let privKey = PrivateKey.example(rng)
+      let node = initDiscoveryNode(rng, privKey, localAddress(20302 + i), bootnodes)
+      await node.start()
+      result.add((node, privKey))
+      if delay > 0:
+        await sleepAsync(chronos.milliseconds(delay))
+    except TransportOsError as e:
+      echo "skipping node ",i ,":", e.msg
+
 
 
   #await allFutures(result.mapIt(it.bootstrap())) # this waits for bootstrap based on bootENode, which includes bonding with all its ping pongs


### PR DESCRIPTION
The goal of this WIP PR is to collect patches required to use the sim codebase for large scale DHT emulation, mostly focusing on the DAS use case. Not to be merged, currently just a collection of patches.

Patches currently live in this repository, but they should apply with little changes also in the original nim-eth repo, especially if we merge the code factorisation in https://github.com/status-im/nim-eth/pull/480.

Current approach
- Take real DHT implementation
  - This or Kim's original
- Run it over simulated network
  - Switch UDP to in-memory message passing
  - Add configurable delay, loss, and eventual egress/ingress queuing
- Make it work for large numbers
   - Remove bulk of calculation (e.g. fake encryption)
   - Add some time warp (e.g. 1 emuSec = 10 sec)
   - Eventually add event based simulated time
- Add upload/download code
   - put/get
   - upload / download traffic pattern

